### PR TITLE
Update add.py

### DIFF
--- a/add.py
+++ b/add.py
@@ -39,7 +39,7 @@ try:
                 track = row[TRACK_COL]
                 artist = row[ARTIST_COL]
                 search_query = f"{track} {artist}"
-                search_results = yt.search(search_query)
+                search_results = yt.search(search_query, 'songs')
                 
 
                 retries = 0


### PR DESCRIPTION
Added 'songs' filter to youtube music api search call.

This might be new, but the first unfiltered result for the title track of an album is [almost?] always the album itself. Adding the filter allows for the song result for the title track to be returned instead.